### PR TITLE
Safe call track method

### DIFF
--- a/lib/nexaas/auditor/statistics_trackers/base.rb
+++ b/lib/nexaas/auditor/statistics_trackers/base.rb
@@ -50,7 +50,7 @@ module Nexaas
           begin
             yield(block)
           rescue => exception
-            logger.fatal("role=audit_logger class=#{self.class} measure=errors.unable_to_track exception=#{exception.class}")
+            logger.fatal("role=nexaas-auditor class=#{self.class} measure=errors.unable_to_track exception=#{exception.class}")
           end
         end
 

--- a/lib/nexaas/auditor/statistics_trackers/base.rb
+++ b/lib/nexaas/auditor/statistics_trackers/base.rb
@@ -19,7 +19,7 @@ module Nexaas
           full_name = full_metric_name(name)
           validate_name!(name, full_name)
 
-          send_track(type, full_name, value)
+          safe_call { send_track(type, full_name, value) }
         end
 
         def send_track(type, full_name, value)
@@ -44,6 +44,14 @@ module Nexaas
         # allowed values: Numeric (Integer, Float, Decimal, etc)
         def validate_value!(value, type)
           raise ArgumentError, "unsuported value: #{value} (#{value.class})" unless value.is_a?(Numeric)
+        end
+
+        def safe_call(&block)
+          begin
+            yield(block)
+          rescue => exception
+            logger.fatal("role=audit_logger class=#{self.class} measure=errors.unable_to_track exception=#{exception.class}")
+          end
         end
 
       end

--- a/spec/nexaas/auditor/statistics_trackers/stathat_spec.rb
+++ b/spec/nexaas/auditor/statistics_trackers/stathat_spec.rb
@@ -59,7 +59,7 @@ describe Nexaas::Auditor::StatisticsTrackers::Stathat do
       it "log the error to fatal" do
         expect(subject.logger).
           to receive(:fatal).
-          with("role=audit_logger class=Nexaas::Auditor::StatisticsTrackers::Stathat measure=errors.unable_to_track exception=Net::OpenTimeout")
+          with("role=nexaas-auditor class=Nexaas::Auditor::StatisticsTrackers::Stathat measure=errors.unable_to_track exception=Net::OpenTimeout")
         subject.track_count(metric: 'foo.bar', value: 42)
       end
     end
@@ -99,7 +99,7 @@ describe Nexaas::Auditor::StatisticsTrackers::Stathat do
       it "log the error to fatal" do
         expect(subject.logger).
           to receive(:fatal).
-          with("role=audit_logger class=Nexaas::Auditor::StatisticsTrackers::Stathat measure=errors.unable_to_track exception=Net::OpenTimeout")
+          with("role=nexaas-auditor class=Nexaas::Auditor::StatisticsTrackers::Stathat measure=errors.unable_to_track exception=Net::OpenTimeout")
         subject.track_value(metric: 'foo.bar', value: 5.0)
       end
     end


### PR DESCRIPTION
We get some errors when using Stathat as tracker on events started on sidekiq, as it makes synchronous calls to StatHat.
Added a safe call for send_track and log if it encountered an error.
